### PR TITLE
Disable automatic browser launch in development.  There was an issue …

### DIFF
--- a/McpPromptServer/Properties/launchSettings.json
+++ b/McpPromptServer/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "McpPromptServer": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
…sending blank requests that was causing a session not found error on MCP Server on start.